### PR TITLE
Use getter for T in UnconstrainedTimeIndexedProblem

### DIFF
--- a/src/optpp_core.cpp
+++ b/src/optpp_core.cpp
@@ -185,7 +185,6 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
 
     Eigen::VectorXd x(problem_->N);
     Eigen::VectorXd x_prev = problem_->getInitialTrajectory()[0];
-    Eigen::VectorXd x_prev_prev = x_prev;
     double T = (double)problem_->T;
     double ct = 1.0/problem_->tau/T;
 
@@ -220,7 +219,6 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
             }
             result = NLPGradient;
         }
-        x_prev_prev = x_prev;
         x_prev = x;
     }
 

--- a/src/optpp_core.cpp
+++ b/src/optpp_core.cpp
@@ -182,7 +182,6 @@ void UnconstrainedTimeIndexedProblemWrapper::updateCallbackFD(int n, const Colum
 void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const ColumnVector& x_opp, double& fx, ColumnVector& gx, int& result)
 {
     if(n!=n_) throw_pretty("Invalid OPT++ state size, expecting "<<n_<<" got "<<n);
-    fx = 0.0;
 
     Eigen::VectorXd x(problem_->N);
     Eigen::VectorXd x_prev = problem_->getInitialTrajectory()[0];
@@ -191,6 +190,9 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
     double ct = 1.0/problem_->tau/T;
 
     Eigen::VectorXd dx;
+
+    problem_->Update(x_prev, 0);
+    fx = problem_->getScalarTaskCost(0);
 
     for(int t=1; t<problem_->T; t++)
     {

--- a/src/optpp_core.cpp
+++ b/src/optpp_core.cpp
@@ -202,20 +202,18 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
 
         if (mode & NLPFunction)
         {
-            fx += problem_->getScalarCost(t)*ct +
-                    ct*dx.transpose()*problem_->W*dx;
+            fx += problem_->getScalarTaskCost(t) + problem_->getScalarTransitionCost(t);
             result = NLPFunction;
         }
 
         if (mode & NLPGradient)
         {
-            Eigen::VectorXd J = problem_->getScalarJacobian(t)*ct
-                    + 2.0*ct*problem_->W*dx;
+            Eigen::VectorXd J_control = problem_->getScalarTransitionJacobian(t);
+            Eigen::VectorXd J = problem_->getScalarTaskJacobian(t) + J_control;
             for(int i=0; i<problem_->N; i++) gx((t-1)*problem_->N+i+1) = J(i);
             if(t>1)
             {
-                J=-2.0*ct*problem_->W*dx;
-                for(int i=0; i<problem_->N; i++) gx((t-2)*problem_->N+i+1) += J(i);
+                for(int i=0; i<problem_->N; i++) gx((t-2)*problem_->N+i+1) += -J_control(i);
             }
             result = NLPGradient;
         }

--- a/src/optpp_core.cpp
+++ b/src/optpp_core.cpp
@@ -158,7 +158,7 @@ void FDNLF1WrapperUEPP::initFcn()
 
 
 UnconstrainedTimeIndexedProblemWrapper::UnconstrainedTimeIndexedProblemWrapper(UnconstrainedTimeIndexedProblem_ptr problem) :
-    problem_(problem), n_(problem_->N*(problem_->T-1))
+    problem_(problem), n_(problem_->N*(problem_->getT()-1))
 {
 
 }
@@ -185,15 +185,13 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
 
     Eigen::VectorXd x(problem_->N);
     Eigen::VectorXd x_prev = problem_->getInitialTrajectory()[0];
-    double T = (double)problem_->T;
-    double ct = 1.0/problem_->tau/T;
 
     Eigen::VectorXd dx;
 
     problem_->Update(x_prev, 0);
     fx = problem_->getScalarTaskCost(0);
 
-    for(int t=1; t<problem_->T; t++)
+    for(int t=1; t<problem_->getT(); t++)
     {
         for(int i=0; i<problem_->N; i++) x(i) = x_opp((t-1)*problem_->N+i+1);
 
@@ -233,7 +231,7 @@ void UnconstrainedTimeIndexedProblemWrapper::init(int n, ColumnVector& x)
     if(n!=n_) throw_pretty("Invalid OPT++ state size, expecting "<<n_<<" got "<<n);
     const std::vector<Eigen::VectorXd>& init = problem_->getInitialTrajectory();
     x.ReSize(n);
-    for(int t=1; t<problem_->T; t++)
+    for(int t=1; t<problem_->getT(); t++)
         for(int i=0; i<problem_->N; i++)
             x((t-1)*problem_->N+i+1) = init[t](i);
     hasBeenInitialized = false;

--- a/src/optpp_traj.cpp
+++ b/src/optpp_traj.cpp
@@ -70,7 +70,7 @@ void OptppTrajLBFGS::Solve(Eigen::MatrixXd& solution)
     prob_->preupdate();
     prob_->resetCostEvolution(parameters_.MaxIterations);
 
-    solution.resize(prob_->T, prob_->N);
+    solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
     int iter, feval, geval, ret;
 
@@ -99,7 +99,7 @@ void OptppTrajLBFGS::Solve(Eigen::MatrixXd& solution)
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();
-        for(int t=1; t<prob_->T; t++)
+        for(int t=1; t<prob_->getT(); t++)
             for(int i=0; i<prob_->N; i++)
                 solution(t,i) = sol((t-1)*prob_->N+i+1);
         iter = solver->getIter();
@@ -142,7 +142,7 @@ void OptppTrajCG::Solve(Eigen::MatrixXd& solution)
     prob_->preupdate();
     prob_->resetCostEvolution(parameters_.MaxIterations);
 
-    solution.resize(prob_->T, prob_->N);
+    solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
     int iter, feval, geval, ret;
 
@@ -170,7 +170,7 @@ void OptppTrajCG::Solve(Eigen::MatrixXd& solution)
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();
-        for(int t=1; t<prob_->T; t++)
+        for(int t=1; t<prob_->getT(); t++)
             for(int i=0; i<prob_->N; i++)
                 solution(t,i) = sol((t-1)*prob_->N+i+1);
         iter = solver->getIter();
@@ -214,7 +214,7 @@ void OptppTrajQNewton::Solve(Eigen::MatrixXd& solution)
     prob_->preupdate();
     prob_->resetCostEvolution(parameters_.MaxIterations + 1);
 
-    solution.resize(prob_->T, prob_->N);
+    solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
     int iter, feval, geval, ret;
 
@@ -242,7 +242,7 @@ void OptppTrajQNewton::Solve(Eigen::MatrixXd& solution)
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();
-        for(int t=1; t<prob_->T; t++)
+        for(int t=1; t<prob_->getT(); t++)
             for(int i=0; i<prob_->N; i++)
                 solution(t,i) = sol((t-1)*prob_->N+i+1);
         iter = solver->getIter();
@@ -287,7 +287,7 @@ void OptppTrajFDNewton::Solve(Eigen::MatrixXd& solution)
     prob_->preupdate();
     prob_->resetCostEvolution(parameters_.MaxIterations);
 
-    solution.resize(prob_->T, prob_->N);
+    solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
     int iter, feval, geval, ret;
 
@@ -315,7 +315,7 @@ void OptppTrajFDNewton::Solve(Eigen::MatrixXd& solution)
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();
-        for(int t=1; t<prob_->T; t++)
+        for(int t=1; t<prob_->getT(); t++)
             for(int i=0; i<prob_->N; i++)
                 solution(t,i) = sol((t-1)*prob_->N+i+1);
         iter = solver->getIter();
@@ -362,7 +362,7 @@ void OptppTrajGSS::Solve(Eigen::MatrixXd& solution)
     prob_->preupdate();
     prob_->resetCostEvolution(parameters_.MaxIterations);
 
-    solution.resize(prob_->T, prob_->N);
+    solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
     int iter, feval, geval, ret;
 
@@ -381,7 +381,7 @@ void OptppTrajGSS::Solve(Eigen::MatrixXd& solution)
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();
-        for(int t=1; t<prob_->T; t++)
+        for(int t=1; t<prob_->getT(); t++)
             for(int i=0; i<prob_->N; i++)
                 solution(t,i) = sol((t-1)*prob_->N+i+1);
         iter = solver->getIter();


### PR DESCRIPTION
In order to allow optimising different trajectory lengths without having to reinstantiate everything, T is now a private variable and comes with a getter and setter. Depends on (yet to be pushed) upstream PR.

Based on top of #2 