### PR TITLE
Unify solver parameters and add step tolerance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,19 @@ find_package(catkin REQUIRED COMPONENTS
   optpp_catkin
 )
 
-AddInitializer(OptppIKLBFGS OptppIKCG OptppIKQNewton OptppIKFDNewton OptppIKGSS
-    OptppTrajLBFGS OptppTrajCG OptppTrajQNewton OptppTrajFDNewton OptppTrajGSS)
+AddInitializer(
+  OptppMotionSolver
+  OptppIKLBFGS
+  OptppIKCG
+  OptppIKQNewton
+  OptppIKFDNewton
+  OptppIKGSS
+  OptppTrajLBFGS
+  OptppTrajCG
+  OptppTrajQNewton
+  OptppTrajFDNewton
+  OptppTrajGSS
+)
 GenInitializers()
 
 catkin_package(

--- a/init/OptppIKCG.in
+++ b/init/OptppIKCG.in
@@ -1,6 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
+extend <optpp_solver/OptppMotionSolver>

--- a/init/OptppIKFDNewton.in
+++ b/init/OptppIKFDNewton.in
@@ -1,6 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
+extend <optpp_solver/OptppMotionSolver>

--- a/init/OptppIKLBFGS.in
+++ b/init/OptppIKLBFGS.in
@@ -1,6 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
+extend <optpp_solver/OptppMotionSolver>

--- a/init/OptppIKQNewton.in
+++ b/init/OptppIKQNewton.in
@@ -1,6 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
+extend <optpp_solver/OptppMotionSolver>

--- a/init/OptppMotionSolver.in
+++ b/init/OptppMotionSolver.in
@@ -1,0 +1,7 @@
+extend <exotica/MotionSolver>
+Optional bool UseFiniteDifferences = false;
+Optional double GradientTolerance = 1e-6;
+Optional int MaxBacktrackIterations = 10;
+Optional double LineSearchTolerance = 1e-4;
+Optional int MaxIterations = 100;
+Optional double StepTolerance = 2.2e-16;

--- a/init/OptppTrajCG.in
+++ b/init/OptppTrajCG.in
@@ -1,6 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
+extend <optpp_solver/OptppMotionSolver>

--- a/init/OptppTrajFDNewton.in
+++ b/init/OptppTrajFDNewton.in
@@ -1,6 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
+extend <optpp_solver/OptppMotionSolver>

--- a/init/OptppTrajLBFGS.in
+++ b/init/OptppTrajLBFGS.in
@@ -1,7 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
-Optional double StepTolerance = 2.2e-16;
+extend <optpp_solver/OptppMotionSolver>

--- a/init/OptppTrajQNewton.in
+++ b/init/OptppTrajQNewton.in
@@ -1,6 +1,1 @@
-extend <exotica/MotionSolver>
-Optional bool UseFiniteDifferences = false;
-Optional double GradientTolerance = 1e-6;
-Optional int MaxBacktrackIterations = 10;
-Optional double LineSearchTolerance = 1e-4;
-Optional int MaxIterations = 100;
+extend <optpp_solver/OptppMotionSolver>

--- a/src/optpp_ik.cpp
+++ b/src/optpp_ik.cpp
@@ -93,6 +93,7 @@ void OptppIKLBFGS::Solve(Eigen::MatrixXd& solution)
         solver->setGradTol(parameters_.GradientTolerance);
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
+        solver->setStepTol(parameters_.StepTolerance);
         solver->setMaxIter(parameters_.MaxIterations);
         ColumnVector W(prob_->N);
         for (int i = 0; i < prob_->N; i++) W(i + 1) = prob_->W(i, i);
@@ -162,6 +163,7 @@ void OptppIKCG::Solve(Eigen::MatrixXd& solution)
         solver->setGradTol(parameters_.GradientTolerance);
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
+        solver->setStepTol(parameters_.StepTolerance);
         solver->setMaxIter(parameters_.MaxIterations);
         ColumnVector W(prob_->N);
         for (int i = 0; i < prob_->N; i++) W(i + 1) = prob_->W(i, i);
@@ -231,6 +233,7 @@ void OptppIKQNewton::Solve(Eigen::MatrixXd& solution)
         solver->setGradTol(parameters_.GradientTolerance);
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
+        solver->setStepTol(parameters_.StepTolerance);
         solver->setMaxIter(parameters_.MaxIterations);
         ColumnVector W(prob_->N);
         for (int i = 0; i < prob_->N; i++) W(i + 1) = prob_->W(i, i);
@@ -300,6 +303,7 @@ void OptppIKFDNewton::Solve(Eigen::MatrixXd& solution)
         solver->setGradTol(parameters_.GradientTolerance);
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
+        solver->setStepTol(parameters_.StepTolerance);
         solver->setMaxIter(parameters_.MaxIterations);
         ColumnVector W(prob_->N);
         for (int i = 0; i < prob_->N; i++) W(i + 1) = prob_->W(i, i);

--- a/src/optpp_traj.cpp
+++ b/src/optpp_traj.cpp
@@ -164,6 +164,7 @@ void OptppTrajCG::Solve(Eigen::MatrixXd& solution)
         solver->setGradTol(parameters_.GradientTolerance);
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
+        solver->setStepTol(parameters_.StepTolerance);
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();
@@ -233,6 +234,7 @@ void OptppTrajQNewton::Solve(Eigen::MatrixXd& solution)
         solver->setGradTol(parameters_.GradientTolerance);
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
+        solver->setStepTol(parameters_.StepTolerance);
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();
@@ -302,6 +304,7 @@ void OptppTrajFDNewton::Solve(Eigen::MatrixXd& solution)
         solver->setGradTol(parameters_.GradientTolerance);
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
+        solver->setStepTol(parameters_.StepTolerance);
         solver->setMaxIter(parameters_.MaxIterations);
         solver->optimize();
         ColumnVector sol = nlf->getXc();


### PR DESCRIPTION
This makes all initialisers use the same parameters for maximum iterations and convergence tolerances. 

It also adds step tolerance to QNewton, FDNewton, CG, and L-BFGS. This was previously only set only for the trajectory L-BFGS solver thus resulting in different behaviours when comparing solvers.