### PR TITLE
Fix cost reporting

### DIFF
--- a/src/optpp_core.cpp
+++ b/src/optpp_core.cpp
@@ -86,8 +86,11 @@ void UnconstrainedEndPoseProblemWrapper::update(int mode, int n, const ColumnVec
     int iter = solver_->getIter();
     if (iter == 1) hasBeenInitialized = true;
     if (!hasBeenInitialized) iter = 0;
-    // HIGHLIGHT_NAMED("UEPPW::update", "iter: " << iter << " cost: " << fx)
-    problem_->setCostEvolution(iter, fx);
+    if (mode & NLPFunction)
+    {
+        // HIGHLIGHT_NAMED("UEPPW::update", "mode: " << mode << " iter: " << iter << " cost: " << fx << " (internal solver iter=" << solver_->getIter() << ")");
+        problem_->setCostEvolution(iter, fx);
+    }
 }
 
 void UnconstrainedEndPoseProblemWrapper::init(int n, ColumnVector& x)
@@ -174,7 +177,7 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
     Eigen::VectorXd x = problem_->getInitialTrajectory()[0];
 
     problem_->Update(x, 0);
-    fx = problem_->getScalarTaskCost(0);
+    if (mode & NLPFunction) fx = problem_->getScalarTaskCost(0);
 
     for (int t = 1; t < problem_->getT(); t++)
     {
@@ -204,8 +207,11 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
     int iter = solver_->getIter();
     if (iter == 1) hasBeenInitialized = true;
     if (!hasBeenInitialized) iter = 0;
-    // HIGHLIGHT_NAMED("UTIPW::update", "iter: " << iter << " cost: " << fx)
-    problem_->setCostEvolution(iter, fx);
+    if (mode & NLPFunction)
+    {
+        // HIGHLIGHT_NAMED("UTIPW::update", "mode: " << mode << " iter: " << iter << " cost: " << fx << " (internal solver iter=" << solver_->getIter() << ")");
+        problem_->setCostEvolution(iter, fx);
+    }
 }
 
 void UnconstrainedTimeIndexedProblemWrapper::init(int n, ColumnVector& x)

--- a/src/optpp_core.cpp
+++ b/src/optpp_core.cpp
@@ -171,20 +171,15 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
 {
     if (n != n_) throw_pretty("Invalid OPT++ state size, expecting " << n_ << " got " << n);
 
-    Eigen::VectorXd x(problem_->N);
-    Eigen::VectorXd x_prev = problem_->getInitialTrajectory()[0];
+    Eigen::VectorXd x = problem_->getInitialTrajectory()[0];
 
-    Eigen::VectorXd dx;
-
-    problem_->Update(x_prev, 0);
+    problem_->Update(x, 0);
     fx = problem_->getScalarTaskCost(0);
 
     for (int t = 1; t < problem_->getT(); t++)
     {
         for (int i = 0; i < problem_->N; i++) x(i) = x_opp((t - 1) * problem_->N + i + 1);
-
         problem_->Update(x, t);
-        dx = x - x_prev;
 
         if (mode & NLPFunction)
         {
@@ -203,7 +198,6 @@ void UnconstrainedTimeIndexedProblemWrapper::update(int mode, int n, const Colum
             }
             result = NLPGradient;
         }
-        x_prev = x;
     }
 
     // Store cost

--- a/src/optpp_ik.cpp
+++ b/src/optpp_ik.cpp
@@ -117,7 +117,7 @@ void OptppIKLBFGS::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppIKLBFGS", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval << " , Geval: " << geval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppIKLBFGS", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval << ", Geval: " << geval);
     }
 }
 
@@ -187,7 +187,7 @@ void OptppIKCG::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppIKCG", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval << " , Geval: " << geval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppIKCG", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval << ", Geval: " << geval);
     }
 }
 
@@ -257,7 +257,7 @@ void OptppIKQNewton::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppIKQNewton", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval << " , Geval: " << geval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppIKQNewton", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval << ", Geval: " << geval);
     }
 }
 
@@ -327,7 +327,7 @@ void OptppIKFDNewton::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppIKFDNewton", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval << " , Geval: " << geval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppIKFDNewton", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval << ", Geval: " << geval);
     }
 }
 
@@ -386,7 +386,7 @@ void OptppIKGSS::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppIKGSS", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppIKGSS", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval);
     }
 }
 }

--- a/src/optpp_traj.cpp
+++ b/src/optpp_traj.cpp
@@ -55,7 +55,7 @@ void OptppTrajLBFGS::specifyProblem(PlanningProblem_ptr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedTimeIndexedProblem")
     {
-        throw_named("OPT++ IK can't solve problem of type '" << pointer->type() << "'!");
+        throw_named("OPT++ Trajectory can't solve problem of type '" << pointer->type() << "'!");
     }
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(pointer);
@@ -125,7 +125,7 @@ void OptppTrajCG::specifyProblem(PlanningProblem_ptr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedTimeIndexedProblem")
     {
-        throw_named("OPT++ IK can't solve problem of type '" << pointer->type() << "'!");
+        throw_named("OPT++ Trajectory can't solve problem of type '" << pointer->type() << "'!");
     }
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(pointer);
@@ -187,7 +187,7 @@ void OptppTrajCG::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppTrajCG", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval << " , Geval: " << geval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppTrajCG", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval << ", Geval: " << geval);
     }
 }
 
@@ -195,7 +195,7 @@ void OptppTrajQNewton::specifyProblem(PlanningProblem_ptr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedTimeIndexedProblem")
     {
-        throw_named("OPT++ IK can't solve problem of type '" << pointer->type() << "'!");
+        throw_named("OPT++ Trajectory can't solve problem of type '" << pointer->type() << "'!");
     }
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(pointer);
@@ -216,7 +216,7 @@ void OptppTrajQNewton::Solve(Eigen::MatrixXd& solution)
     Try
     {
         std::shared_ptr<NLP1> nlf;
-        std::shared_ptr<OPTPP::OptQNewton> solver(new OPTPP::OptQNewton());
+        std::shared_ptr<OPTPP::OptQNewton> solver;
         if (parameters_.UseFiniteDifferences)
         {
             auto nlf_local = UnconstrainedTimeIndexedProblemWrapper(prob_).getFDNLF1();
@@ -257,7 +257,7 @@ void OptppTrajQNewton::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppTrajQNewton", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval << " , Geval: " << geval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppTrajQNewton", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval << ", Geval: " << geval);
     }
 }
 
@@ -265,7 +265,7 @@ void OptppTrajFDNewton::specifyProblem(PlanningProblem_ptr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedTimeIndexedProblem")
     {
-        throw_named("OPT++ IK can't solve problem of type '" << pointer->type() << "'!");
+        throw_named("OPT++ Trajectory can't solve problem of type '" << pointer->type() << "'!");
     }
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(pointer);
@@ -327,7 +327,7 @@ void OptppTrajFDNewton::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppTrajFDNewton", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval << " , Geval: " << geval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppTrajFDNewton", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval << ", Geval: " << geval);
     }
 }
 
@@ -335,7 +335,7 @@ void OptppTrajGSS::specifyProblem(PlanningProblem_ptr pointer)
 {
     if (pointer->type() != "exotica::UnconstrainedTimeIndexedProblem")
     {
-        throw_named("OPT++ IK can't solve problem of type '" << pointer->type() << "'!");
+        throw_named("OPT++ Trajectory can't solve problem of type '" << pointer->type() << "'!");
     }
     MotionSolver::specifyProblem(pointer);
     prob_ = std::static_pointer_cast<UnconstrainedTimeIndexedProblem>(pointer);
@@ -386,7 +386,7 @@ void OptppTrajGSS::Solve(Eigen::MatrixXd& solution)
 
     if (debug_)
     {
-        HIGHLIGHT_NAMED(object_name_ + " OptppTrajGSS", "Time: " << planning_time_ << " ,Status: " << ret << " , Iterations: " << iter << " ,Feval: " << feval);
+        HIGHLIGHT_NAMED(object_name_ + " OptppTrajGSS", "Time: " << planning_time_ << ", Status: " << ret << ", Iterations: " << iter << ", Feval: " << feval);
     }
 }
 }


### PR DESCRIPTION
Only store cost to evolution if we are evaluating either Function or Function and Gradient - do not store if it's a gradient only evaluation (mode==2). Avoids accidentally overwriting the whole roll-out cost with a single 0th-timestep task cost. 