### PR TITLE
Use inherited planning time and max iterations

### DIFF
--- a/include/optpp_solver/otpp_ik.h
+++ b/include/optpp_solver/otpp_ik.h
@@ -56,14 +56,16 @@ class OptppIKLBFGS : public MotionSolver, public Instantiable<OptppIKLBFGSInitia
 public:
     OptppIKLBFGS() {}
     virtual ~OptppIKLBFGS() {}
-    virtual void Instantiate(OptppIKLBFGSInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppIKLBFGSInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedEndPoseProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppIKLBFGSInitializer parameters_;
 
@@ -77,14 +79,16 @@ class OptppIKCG : public MotionSolver, public Instantiable<OptppIKCGInitializer>
 public:
     OptppIKCG() {}
     virtual ~OptppIKCG() {}
-    virtual void Instantiate(OptppIKCGInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppIKCGInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedEndPoseProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppIKCGInitializer parameters_;
 
@@ -98,14 +102,16 @@ class OptppIKQNewton : public MotionSolver, public Instantiable<OptppIKQNewtonIn
 public:
     OptppIKQNewton() {}
     virtual ~OptppIKQNewton() {}
-    virtual void Instantiate(OptppIKQNewtonInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppIKQNewtonInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedEndPoseProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppIKQNewtonInitializer parameters_;
 
@@ -119,14 +125,16 @@ class OptppIKFDNewton : public MotionSolver, public Instantiable<OptppIKFDNewton
 public:
     OptppIKFDNewton() {}
     virtual ~OptppIKFDNewton() {}
-    virtual void Instantiate(OptppIKFDNewtonInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppIKFDNewtonInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedEndPoseProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppIKFDNewtonInitializer parameters_;
 
@@ -140,14 +148,16 @@ class OptppIKGSS : public MotionSolver, public Instantiable<OptppIKGSSInitialize
 public:
     OptppIKGSS() {}
     virtual ~OptppIKGSS() {}
-    virtual void Instantiate(OptppIKGSSInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppIKGSSInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedEndPoseProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppIKGSSInitializer parameters_;
 

--- a/include/optpp_solver/otpp_traj.h
+++ b/include/optpp_solver/otpp_traj.h
@@ -56,14 +56,16 @@ class OptppTrajLBFGS : public MotionSolver, public Instantiable<OptppTrajLBFGSIn
 public:
     OptppTrajLBFGS() {}
     virtual ~OptppTrajLBFGS() {}
-    virtual void Instantiate(OptppTrajLBFGSInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppTrajLBFGSInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedTimeIndexedProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppTrajLBFGSInitializer parameters_;
 
@@ -77,14 +79,16 @@ class OptppTrajCG : public MotionSolver, public Instantiable<OptppTrajCGInitiali
 public:
     OptppTrajCG() {}
     virtual ~OptppTrajCG() {}
-    virtual void Instantiate(OptppTrajCGInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppTrajCGInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedTimeIndexedProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppTrajCGInitializer parameters_;
 
@@ -98,14 +102,16 @@ class OptppTrajQNewton : public MotionSolver, public Instantiable<OptppTrajQNewt
 public:
     OptppTrajQNewton() {}
     virtual ~OptppTrajQNewton() {}
-    virtual void Instantiate(OptppTrajQNewtonInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppTrajQNewtonInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedTimeIndexedProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppTrajQNewtonInitializer parameters_;
 
@@ -119,14 +125,16 @@ class OptppTrajFDNewton : public MotionSolver, public Instantiable<OptppTrajFDNe
 public:
     OptppTrajFDNewton() {}
     virtual ~OptppTrajFDNewton() {}
-    virtual void Instantiate(OptppTrajFDNewtonInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppTrajFDNewtonInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedTimeIndexedProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppTrajFDNewtonInitializer parameters_;
 
@@ -140,14 +148,16 @@ class OptppTrajGSS : public MotionSolver, public Instantiable<OptppTrajGSSInitia
 public:
     OptppTrajGSS() {}
     virtual ~OptppTrajGSS() {}
-    virtual void Instantiate(OptppTrajGSSInitializer& init) { parameters_ = init; }
+    virtual void Instantiate(OptppTrajGSSInitializer& init)
+    {
+        parameters_ = init;
+        setNumberOfMaxIterations(parameters_.MaxIterations);
+    }
     virtual void Solve(Eigen::MatrixXd& solution);
 
     virtual void specifyProblem(PlanningProblem_ptr pointer);
 
     UnconstrainedTimeIndexedProblem_ptr& getProblem() { return prob_; }
-    double planning_time_;
-
 private:
     OptppTrajGSSInitializer parameters_;
 

--- a/init/OptppMotionSolver.in
+++ b/init/OptppMotionSolver.in
@@ -1,8 +1,8 @@
 extend <exotica/MotionSolver>
 Optional bool UseFiniteDifferences = false;
-Optional double FunctionTolerance = 1e-6;
-Optional double MinStep = 1e-9;
-Optional double GradientTolerance = 1e-6;
+Optional double FunctionTolerance = 1e-4;
+Optional double MinStep = 2.2e-16;
+Optional double GradientTolerance = 0.9;
 Optional int MaxBacktrackIterations = 10;
 Optional double LineSearchTolerance = 1e-4;
 Optional int MaxIterations = 100;

--- a/src/optpp_ik.cpp
+++ b/src/optpp_ik.cpp
@@ -67,7 +67,7 @@ void OptppIKLBFGS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -139,7 +139,7 @@ void OptppIKCG::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -211,7 +211,7 @@ void OptppIKQNewton::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -283,7 +283,7 @@ void OptppIKFDNewton::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -355,7 +355,7 @@ void OptppIKGSS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;

--- a/src/optpp_ik.cpp
+++ b/src/optpp_ik.cpp
@@ -67,7 +67,7 @@ void OptppIKLBFGS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -94,7 +94,7 @@ void OptppIKLBFGS::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         ColumnVector W(prob_->N);
@@ -139,7 +139,7 @@ void OptppIKCG::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -166,7 +166,7 @@ void OptppIKCG::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         ColumnVector W(prob_->N);
@@ -211,7 +211,7 @@ void OptppIKQNewton::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -238,7 +238,7 @@ void OptppIKQNewton::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         ColumnVector W(prob_->N);
@@ -283,7 +283,7 @@ void OptppIKFDNewton::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -310,7 +310,7 @@ void OptppIKFDNewton::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         ColumnVector W(prob_->N);
@@ -355,7 +355,7 @@ void OptppIKGSS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(1, prob_->N);
     int iter, feval, geval, ret;
@@ -372,7 +372,7 @@ void OptppIKGSS::Solve(Eigen::MatrixXd& solution)
         nlf_local->setSolver(std::static_pointer_cast<OPTPP::OptimizeClass>(solver));
 
         solver->setFullSearch(true);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         ColumnVector W(prob_->N);
         for (int i = 0; i < prob_->N; i++) W(i + 1) = prob_->W(i, i);
         solver->setXScale(W);

--- a/src/optpp_traj.cpp
+++ b/src/optpp_traj.cpp
@@ -67,7 +67,7 @@ void OptppTrajLBFGS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -139,7 +139,7 @@ void OptppTrajCG::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -283,7 +283,7 @@ void OptppTrajFDNewton::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -355,7 +355,7 @@ void OptppTrajGSS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(getNumberOfMaxIterations());
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];

--- a/src/optpp_traj.cpp
+++ b/src/optpp_traj.cpp
@@ -67,7 +67,7 @@ void OptppTrajLBFGS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -95,7 +95,7 @@ void OptppTrajLBFGS::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         solver->optimize();
@@ -139,7 +139,7 @@ void OptppTrajCG::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -167,7 +167,7 @@ void OptppTrajCG::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         solver->optimize();
@@ -211,7 +211,7 @@ void OptppTrajQNewton::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations + 1);
+    prob_->resetCostEvolution(getNumberOfMaxIterations() + 1);
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -239,7 +239,7 @@ void OptppTrajQNewton::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         solver->optimize();
@@ -283,7 +283,7 @@ void OptppTrajFDNewton::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -311,7 +311,7 @@ void OptppTrajFDNewton::Solve(Eigen::MatrixXd& solution)
         solver->setMaxBacktrackIter(parameters_.MaxBacktrackIterations);
         solver->setLineSearchTol(parameters_.LineSearchTolerance);
         solver->setStepTol(parameters_.StepTolerance);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->setFcnTol(parameters_.FunctionTolerance);
         solver->setMinStep(parameters_.MinStep);
         solver->optimize();
@@ -355,7 +355,7 @@ void OptppTrajGSS::Solve(Eigen::MatrixXd& solution)
 
     if (!prob_) throw_named("Solver has not been initialized!");
     prob_->preupdate();
-    prob_->resetCostEvolution(parameters_.MaxIterations);
+    prob_->resetCostEvolution(getNumberOfMaxIterations());
 
     solution.resize(prob_->getT(), prob_->N);
     solution.row(0) = prob_->getInitialTrajectory()[0];
@@ -373,7 +373,7 @@ void OptppTrajGSS::Solve(Eigen::MatrixXd& solution)
         nlf_local->setSolver(std::static_pointer_cast<OPTPP::OptimizeClass>(solver));
 
         solver->setFullSearch(true);
-        solver->setMaxIter(parameters_.MaxIterations);
+        solver->setMaxIter(getNumberOfMaxIterations());
         solver->optimize();
         ColumnVector sol = nlf->getXc();
         for (int t = 1; t < prob_->getT(); t++)


### PR DESCRIPTION
Uses some functions of an upcoming exotica pull request allowing maximum iterations to be set at runtime and the planning time to be read. Moves commonly used functionality to the MotionSolver class so that we can have them the same across solvers.